### PR TITLE
✨ feat(analytics): make Umami DNT behavior configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -334,6 +334,9 @@ enable_csp = true
 # Leave this field empty if you're using the service's default hosting.
 # self_hosted_url = ""
 
+# Optional: For Umami, enable this option to respect users' Do Not Track (DNT) settings. The default is true.
+do_not_track = true
+
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup
 [extra.giscus]


### PR DESCRIPTION
This PR updates the example `config.toml` to include the `do_not_track` option under `[extra.analytics]`, introduced in welpo/tabi#536. 

This setting allows users to enable `data-do-not-track="true"` for Umami, making the site respect visitors’ Do Not Track (DNT) browser settings.

The default value is set to `true` with a comment explaining its usage. This addition helps users adopt the new feature easily without having to read through all the documentation changes.

No functional changes are made — this is purely a documentation/config example update.